### PR TITLE
SortByColumn in descending direction for issues should use `:desc` instead of `:rev` keyword

### DIFF
--- a/src/api/issues.rs
+++ b/src/api/issues.rs
@@ -574,7 +574,7 @@ impl std::fmt::Display for SortByColumn {
                 write!(f, "{}", column_name)
             }
             SortByColumn::Reverse { column_name } => {
-                write!(f, "{}:rev", column_name)
+                write!(f, "{}:desc", column_name)
             }
         }
     }


### PR DESCRIPTION
When using descend issues, we have to use the `:desc` keyword.  
See parameters section in https://www.redmine.org/projects/redmine/wiki/rest_issues