### PR TITLE
Optional rustls tls provider

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ categories = [ "api-bindings" ]
 edition = "2021"
 exclude = [ ".env", "tarpaulin-report.html", "tarpaulin-report.json" ]
 
+[features]
+rustls-tls = ["reqwest/rustls-tls"]
+
 [profile.release]
 # do not strip debug info from release builds, useful for debugging those, cargo-flamegraph profiling or similar use cases
 debug = true
@@ -34,7 +37,7 @@ version = "0.1.34"
 features = [ "log" ]
 
 [dependencies.reqwest]
-version = "0.11.10"
+version = "0.11"
 features = [ "blocking", "json" ]
 
 [dependencies.time]

--- a/src/api.rs
+++ b/src/api.rs
@@ -113,9 +113,12 @@ impl Redmine {
     ///
     /// # Errors
     ///
-    /// Currently this can not fail but it returns a Result for future proofing the API
+    /// This will return [`crate::Error::ReqwestError`] if initialization of Reqwest client is failed.
     pub fn new(redmine_url: url::Url, api_key: &str) -> Result<Self, crate::Error> {
+        #[cfg(not(feature = "rustls-tls"))]
         let client = Client::new();
+        #[cfg(feature = "rustls-tls")]
+        let client = Client::builder().use_rustls_tls().build()?;
 
         Ok(Self {
             client,


### PR DESCRIPTION
Native TLS providers on Windows doesn't work for servers with TLS 1.3 only supported. Feature rustls-tls added to the crate to overcome this limitation. I'm not native English speaker, and I can't document this.