### PR TITLE
added support for using the native TLS implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ exclude = [".env", "tarpaulin-report.html", "tarpaulin-report.json"]
 
 [features]
 rustls-tls = ["reqwest/rustls-tls"]
+native-tls = ["reqwest/native-tls"]
 
 [profile.release]
 # do not strip debug info from release builds, useful for debugging those, cargo-flamegraph profiling or similar use cases
@@ -40,6 +41,6 @@ dotenvy = "0.15.7"
 finally-block = "0.2.0"
 function_name = "0.3.0"
 pretty_assertions = "1.4.1"
-reqwest = { version = "0.12.18", default-features = false, features = [ "charset", "http2", "rustls-tls", "macos-system-configuration" ] }
+reqwest = { version = "0.12.18", default-features = false, features = [ "charset", "default-tls", "http2", "rustls-tls", "macos-system-configuration" ] }
 tokio = { version = "1.45.1", features = ["full"] }
 tracing-test = "0.2.5"

--- a/src/api.rs
+++ b/src/api.rs
@@ -449,10 +449,12 @@ impl RedmineAsync {
     ///
     /// This will return [`crate::Error::ReqwestError`] if initialization of Reqwest client is failed.
     pub fn new(redmine_url: url::Url, api_key: &str) -> Result<Self, crate::Error> {
-        #[cfg(not(feature = "rustls-tls"))]
+        #[cfg(all(not(feature = "rustls-tls"),not(feature = "native-tls")))]
         let client = reqwest::Client::new();
         #[cfg(feature = "rustls-tls")]
         let client = reqwest::Client::builder().use_rustls_tls().build()?;
+        #[cfg(feature = "native-tls")]
+        let client = reqwest::Client::builder().use_native_tls().build()?;
 
         Ok(Self {
             client,


### PR DESCRIPTION
Hi, I added support for using the native TLS implementation. This change makes it easier to work with redmine installations that use self-signed certificates. I added a new feature flag "native-tls" that enables the corresponding flag in the reqwest crate.
Let me know what you think.